### PR TITLE
Patch: write permissions for update-docs job

### DIFF
--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -35,4 +35,6 @@ jobs:
     uses: ./.github/workflows/doxygen.yml
     needs: test
     secrets: inherit
+    permissions:
+      contents: write  # Required for pushing to the docs branch
 


### PR DESCRIPTION
## Description
- Fix: grant contents:write to reusable workflow (oversight in CD permissions, only verifiable post-merge)
- Note for future: Must grant workflow permissions in both the reusable workflow file (doxygen.yml), and also the caller (docker-cd.yml)

## Skip Checks
- Already verified in PR #43 